### PR TITLE
vue-cli-plugin-babel插件文档保持与英文版同步

### DIFF
--- a/vue-cli-plugin-babel/README.md
+++ b/vue-cli-plugin-babel/README.md
@@ -6,7 +6,7 @@
 
 ## 配置
 
-默认使用 Babel 7 + `babel-loader` + [@vue/babel-preset-app](../vue-babel-preset-app/README.md)，但是可以通过 `.babelrc` 配置使用任何其它 Babel 预设选项或插件。
+默认使用 Babel 7 + `babel-loader` + [@vue/babel-preset-app](../vue-babel-preset-app/README.md)，但是可以通过 `babel.config.js` 配置使用任何其它 Babel 预设选项或插件。
 
 默认情况下，`babel-loader` 会排除 `node_modules` 依赖内部的文件。如果希望显性编译一个依赖的模块，你需要将其添加入 `vue.config.js` 中的 `transpileDependencies` 选项：
 


### PR DESCRIPTION
1. 新版本的vue-cli-plugin-babel插件配置文件为`babel.config.js`